### PR TITLE
Feature create certificates folder

### DIFF
--- a/lib/nubank_sdk/certificate.rb
+++ b/lib/nubank_sdk/certificate.rb
@@ -56,9 +56,19 @@ module NubankSdk
     #
     # @return [File]
     def save(p12)
+      create_folder
+
       File.open("#{FILES_PATH}#{@cpf}.p12", 'wb') do |file|
         file.write p12.to_der
       end
+    end
+
+    # @!visibility private
+    # Create certificates folder
+    #
+    # @return [File]
+    def create_folder
+      Dir.mkdir(FILES_PATH) unless Dir.exist?(FILES_PATH)
     end
 
     # @!visibility private


### PR DESCRIPTION
This pr adds a new method to create a certificates folder if it doesn't exist.

## Testing

- [ ] Pull this pr on your ambient
- [ ] Generate a gem build, and install
```shell
gem build
gem install --local nubank_sdk-0.6.1.gem
```
- [ ] Open ruby console and add the gem
```shell
irb
```
```ruby
require 'nubank_sdk'
```
Delete the certifications folder
```ruby
Dir.delete(NubankSdk::Certificate::FILES_PATH)
```
Try exchange a new certs (follow README.md in root)